### PR TITLE
remove ruby texts on verses

### DIFF
--- a/verse-collector/src/collect.ts
+++ b/verse-collector/src/collect.ts
@@ -52,6 +52,9 @@ export default async function collect(volume: string, book: string, chapter: num
     // remove superscripts on verses
     verseEls.find("sup").remove();
 
+    // remove ruby texts on verses
+    verseEls.find("rt").remove();
+
     const verses = verseEls
         .map(function(_, el) {
             return $(el).text().trim();


### PR DESCRIPTION
## What does this PR do?
This PR removes the `<rt>` tags from Japanese HTML data. The `<rt>` tags are used to denote the pronunciation of kanji characters, but they are unnecessary when converting the content to JSON format.

## How was it tested?
To ensure that the changes do not affect other languages, I compared the `sha256sum` of JSON files generated before and after the code changes. The checksums were identical, confirming that the changes only impact Japanese content.
